### PR TITLE
missions: fix missing return types

### DIFF
--- a/src/smm_client/missions.py
+++ b/src/smm_client/missions.py
@@ -98,14 +98,14 @@ class SMMMission:
         """
         return self.connection.post(self.__url_component(page), data)
 
-    def add_member(self, user: SMMUser) -> None:
+    def add_member(self, user: SMMUser) -> SMMMissionMember:
         """
         Add a member to this mission
         """
         self.post("users/add/", data={"user": user.username})
         return SMMMissionMember(self, user)
 
-    def add_organization(self, organization: SMMOrganization) -> None:
+    def add_organization(self, organization: SMMOrganization) -> SMMMissionOrganization:
         """
         Add an organization to this mission
         """


### PR DESCRIPTION
## Description

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change

## Summary by Sourcery

Bug Fixes:
- Fix missing return types in the 'add_member' and 'add_organization' methods of the missions module.