### PR TITLE
missions: remove logic from f-string

### DIFF
--- a/src/smm_client/missions.py
+++ b/src/smm_client/missions.py
@@ -150,7 +150,8 @@ class SMMMission:
 
         Use include="removed" to see get all assets that were ever in the mission
         """
-        return self.connection.get_json(self.__url_component(f"assets/?include_removed={include == "removed"}"))
+        include_removed = str(include == "removed")
+        return self.connection.get_json(self.__url_component(f"assets/?include_removed={include_removed}"))
 
     def add_waypoint(self, point: SMMPoint, label: str) -> SMMPoi | None:
         """


### PR DESCRIPTION
## Description

This seems to confuse pylint with python 3.11

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change

## Summary by Sourcery

Bug Fixes:
- Fix an issue where logic within an f-string caused confusion for pylint with Python 3.11.