### PR TITLE
mission: add get_organizations function

### DIFF
--- a/src/smm_client/missions.py
+++ b/src/smm_client/missions.py
@@ -12,11 +12,11 @@ from typing import TYPE_CHECKING
 import requests
 
 from smm_client.geometry import SMMLine, SMMPoi, SMMPolygon
+from smm_client.organizations import SMMOrganization
 
 if TYPE_CHECKING:
     from smm_client.assets import SMMAsset, SMMUser
     from smm_client.connection import SMMConnection
-    from smm_client.organizations import SMMOrganization
     from smm_client.types import SMMPoint
 
 
@@ -98,6 +98,12 @@ class SMMMission:
         """
         return self.connection.post(self.__url_component(page), data)
 
+    def get_json(self, page: str):
+        """
+        Get data from a specific url in this mission
+        """
+        return self.connection.get_json(self.__url_component(page))
+
     def add_member(self, user: SMMUser) -> SMMMissionMember:
         """
         Add a member to this mission
@@ -109,8 +115,18 @@ class SMMMission:
         """
         Add an organization to this mission
         """
-        self.post("organizations/add/", data={"organization": organization.id})
+        self.post("organizations/", data={"organization": organization.id})
         return SMMMissionOrganization(self, organization)
+
+    def get_organizations(self) -> list[SMMMissionOrganization]:
+        """
+        Get all the current organizations in this mission
+        """
+        organizations_json = self.get_json("organizations/")
+        return [
+            SMMMissionOrganization(self, SMMOrganization(self.connection, organization["id"], organization["name"]))
+            for organization in organizations_json["organizations"]
+        ]
 
     def add_asset(self, asset: SMMAsset) -> None:
         """


### PR DESCRIPTION
## Description

This makes use of the new support in SMM for getting the organization list It also updates the path to add an organization when this change was implemented.

Relates to https://github.com/canterbury-air-patrol/search-management-map/pull/511

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change

## Summary by Sourcery

Add a new function 'get_organizations' to the missions module to fetch the list of organizations for a mission and update the organization addition path to match the new API endpoint.

New Features:
- Introduce a new function 'get_organizations' to retrieve the list of organizations associated with a mission.

Enhancements:
- Update the path for adding an organization in the 'add_organization' function to align with the new API structure.