### PR TITLE
Fix creating the mission organization list

### DIFF
--- a/src/smm_client/missions.py
+++ b/src/smm_client/missions.py
@@ -136,7 +136,12 @@ class SMMMission:
         """
         organizations_json = self.get_json("organizations/")
         return [
-            SMMMissionOrganization(self, SMMOrganization(self.connection, organization["id"], organization["name"]))
+            SMMMissionOrganization(
+                self,
+                SMMOrganization(
+                    self.connection, organization["organization"]["id"], organization["organization"]["name"]
+                ),
+            )
             for organization in organizations_json["organizations"]
         ]
 


### PR DESCRIPTION
## Description

The returned object is the mission organization, rather than just the organization

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change

## Summary by Sourcery

Bug Fixes:
- Retrieve the correct organization ID and name when fetching mission organizations.