### PR TITLE
Use post to find the closest search

### DIFF
--- a/src/smm_client/assets.py
+++ b/src/smm_client/assets.py
@@ -125,7 +125,7 @@ class SMMAsset:
         Get the nearest search for this asset
         Note: queued searches will be run in order before unqueued searches are looked for by distance
         """
-        data = self.connection.get("/search/find/closest/", data={"asset_id": self.id, "lat": lat, "lon": lon})
+        data = self.connection.post("/search/find/closest/", data={"asset_id": self.id, "lat": lat, "lon": lon})
         try:
             return SMMSearch(self, data.json()["object_url"].split("/")[-1])
         except JSONDecodeError:


### PR DESCRIPTION
## Description

The get function doesn't accept data as an argument, and post is actually supported by this API

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment

## Summary by Sourcery

Bug Fixes:
- Fixed an issue where the API endpoint to find the closest search was using GET instead of POST.