### PR TITLE
Get the mission that an asset is in

### DIFF
--- a/src/smm_client/assets.py
+++ b/src/smm_client/assets.py
@@ -133,6 +133,12 @@ class SMMAsset:
         except JSONDecodeError:
             return None
 
+    def get_asset_data(self):
+        """
+        Get the current data for this asset
+        """
+        return self.connection.get_json(self.__url_component(""))
+
     def __str__(self) -> str:
         return f"{self.name} ({self.id})"
 

--- a/src/smm_client/missions.py
+++ b/src/smm_client/missions.py
@@ -242,3 +242,14 @@ class SMMMission:
             json_obj = results.json()
             return SMMPolygon(self, json_obj["features"][0]["properties"]["pk"])
         return None
+
+    @classmethod
+    def get_mission_for_asset(cls, asset: SMMAsset) -> SMMMission | None:
+        """
+        Get the current mission for the asset
+        """
+        data = asset.get_asset_data()
+        try:
+            return SMMMission(asset.connection, data["mission_id"], data["mission_name"])
+        except KeyError:
+            return None


### PR DESCRIPTION
## Description

Also provides a function to get the data for an asset

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment

## Summary by Sourcery

Add functions to get the mission that an asset is currently in, and to get the data for an asset.

New Features:
- Added `get_mission_for_asset` to retrieve the mission associated with a given asset.
- Added `get_asset_data` to retrieve the data associated with a given asset.