### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hatch-format.yml
+++ b/.github/workflows/hatch-format.yml
@@ -1,4 +1,6 @@
 name: Run Hatch Format
+permissions:
+  contents: read
 
 on: pull_request
 


### PR DESCRIPTION
Potential fix for [https://github.com/canterbury-air-patrol/smm-python/security/code-scanning/2](https://github.com/canterbury-air-patrol/smm-python/security/code-scanning/2)

To fix the issue, you should add an explicit `permissions` block to the workflow or job definition. The recommended approach is to apply this at the workflow root so that all jobs default to least privilege unless they specify otherwise. For a formatting/check job, generally only read access to repository contents is required. Therefore, add the block:

```yaml
permissions:
  contents: read
```

at the top level of your workflow, directly below the workflow `name:` and above `on:`. No code logic changes are needed, but this ensures the GitHub Actions token cannot be abused to update code or perform privileged actions, minimizing attack surface.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add permissions: contents: read to the hatch-format workflow to address code scanning alert #2