### PR TITLE
fix: fetch mission context from /assets/<id>/mission/ endpoint

### DIFF
--- a/src/smm_client/assets.py
+++ b/src/smm_client/assets.py
@@ -175,6 +175,12 @@ class SMMAsset:
         """
         return self.connection.get_json(self.__url_component(""))
 
+    def get_mission_data(self):
+        """
+        Get the mission/search context for this asset
+        """
+        return self.connection.get_json(self.__url_component("mission/"))
+
     def __str__(self) -> str:
         return f"{self.name} ({self.id})"
 

--- a/src/smm_client/missions.py
+++ b/src/smm_client/missions.py
@@ -321,7 +321,7 @@ class SMMMission:
         """
         Get the current mission for the asset
         """
-        data = asset.get_asset_data()
+        data = asset.get_mission_data()
         try:
             return SMMMission(asset.connection, data["mission_id"], data["mission_name"])
         except KeyError:


### PR DESCRIPTION
## Description

Adapts to the search-management-map split of AssetView — mission_id and mission_name were moved from /assets/<id>/ to /assets/<id>/mission/. Adds SMMAsset.get_mission_data() and updates get_mission_for_asset() to use it.

## Summary by Sourcery

Fetch mission context for an asset from the dedicated /assets/<id>/mission/ endpoint instead of the asset detail endpoint.

New Features:
- Add a helper on SMMAsset to retrieve mission/search context data for an asset.

Bug Fixes:
- Update mission lookup to read mission_id and mission_name from the new mission context endpoint for assets.